### PR TITLE
can't include `python` interpreter in -k arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ pip install -r hooks/cloudflare/requirements-python-2.txt
 ## Usage
 
 ```
-$ ./letsencrypt.sh -c -d example.com -t dns-01 -k 'python hooks/cloudflare/hook.py'
+$ ./letsencrypt.sh -c -d example.com -t dns-01 -k 'hooks/cloudflare/hook.py'
 #
 # !! WARNING !! No main config file found, using default config!
 #


### PR DESCRIPTION
Because of the double quotes on `&& "${HOOK}"` in `line 413` of `letsencrypt.sh` these days, you can't include the `python` interpreter in the `-k` option to `letsencrypt.sh` 

Here's the error this commit is fixing:

```
letsencrypt.sh: line 413: python hooks/cloudflare/hook.py: No such file or directory
```

FYI, here's line `413` of `letsencrypt.sh` these days:

```
[[ -n "${HOOK}" ]] && [[ "${HOOK_CHAIN}" != "yes" ]] && "${HOOK}" "deploy_challenge" ${deploy_args[${idx}]}
```
