### PR TITLE
ValueError: too many values to unpack

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -124,7 +124,7 @@ def delete_txt_record(args):
 
 
 def deploy_cert(args):
-    domain, privkey_pem, cert_pem, fullchain_pem = args
+    domain, privkey_pem, cert_pem, fullchain_pem = args[:4]
     logger.info(' + ssl_certificate: {0}'.format(fullchain_pem))
     logger.info(' + ssl_certificate_key: {0}'.format(privkey_pem))
     return


### PR DESCRIPTION
Newer versions of `letsencrypt.sh` pass `chain.pem` info to the hook's `deploy_cert` function. Avoid a `ValueError` by getting just the first 4 arguments. This change should maintain forwards and backwards compatibility for now.

```
  # Wait for hook script to clean the challenge and to deploy cert if used                                             
  [[ -n "${HOOK}" ]] && "${HOOK}" "deploy_cert" "${domain}" "${BASEDIR}/certs/${domain}/privkey.pem"                   
```

"${BASEDIR}/certs/${domain}/cert.pem" "${BASEDIR}/certs/${domain}/fullchain.pem"  
"${BASEDIR}/certs/${domain}/chain.pem"
