### PR TITLE
Feature request: specify custom DNS server(s) when checking whether propagation has succeeded

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -39,11 +39,21 @@ except KeyError:
     logger.error(" + Unable to locate Cloudflare credentials in environment!")
     sys.exit(1)
 
+try:
+    dns_servers = os.environ['CF_DNS_SERVER']
+    dns_servers = dns_servers.split()
+except KeyError:
+    dns_servers = False
 
 def _has_dns_propagated(name, token):
     txt_records = []
     try:
-        dns_response = dns.resolver.query(name, 'TXT')
+        if dns_servers:
+            custom_resolver = dns.resolver.Resolver()
+            custom_resolver.nameservers = dns_servers
+            dns_response = custom_resolver.query(name, 'TXT')
+        else:
+            dns_response = dns.resolver.query(name, 'TXT')
         for rdata in dns_response:
             for txt_record in rdata.strings:
                 txt_records.append(txt_record)

--- a/hook.py
+++ b/hook.py
@@ -40,7 +40,7 @@ except KeyError:
     sys.exit(1)
 
 try:
-    dns_servers = os.environ['CF_DNS_SERVER']
+    dns_servers = os.environ['CF_DNS_SERVERS']
     dns_servers = dns_servers.split()
 except KeyError:
     dns_servers = False


### PR DESCRIPTION
Hello,

Thanks for publishing this script; it's been a huge help for me. :+1: 

I'd like to submit a feature request: support for specifying custom DNS servers, to be used when checking wether DNS has propagated.

This is useful for split-brain DNS scenarios, where the system resolver uses a authoritative nameserver that is not cloudflare. (This may be common for intranet-type scenarios where separate DNS servers are used internally). This prevents the hook from being able to detect propagation unless a different nameserver is used.

This pull request enables support for custom DNS servers when the CF_DNS_SERVERS environment variable is set to one or more DNS servers (whitespace-separated).

Example usage:

```
export CF_DNS_SERVERS='8.8.8.8 8.8.4.4'
./letsencrypt.sh -c -d example.com -t dns-01 -k 'hooks/cloudflare/hook.py'
```

When set, use the specified dns servers when checking whether DNS has propagated.

When unset or empty, continue to use the default system resolver for checking whether DNS has propagated.
