### PR TITLE
python2 requirements ver bump cryptography 1.2.2 -> 1.2.3

### DIFF
--- a/requirements-python-2.txt
+++ b/requirements-python-2.txt
@@ -1,5 +1,5 @@
 cffi==1.5.0
-cryptography==1.2.2
+cryptography==1.2.3
 dnspython==1.12.0
 enum34==1.1.2
 future==0.15.2


### PR DESCRIPTION
resolves bug which prevents compiling against openssl 1.0.2g.
https://github.com/pyca/cryptography/commit/df779dfec9ce87b79e48448aea3c597a4716b29e
