### PR TITLE
Ignore unkown hooks

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -198,9 +198,9 @@ def main(argv):
         'startup_hook': startup_hook,
         'exit_hook': exit_hook
     }
-    logger.info(" + CloudFlare hook executing: {0}".format(argv[0]))
-    ops[argv[0]](argv[1:])
-
+    if argv[0] in ops:
+        logger.info(" + CloudFlare hook executing: {0}".format(argv[0]))
+        ops[argv[0]](argv[1:])
 
 if __name__ == '__main__':
     main(sys.argv[1:])


### PR DESCRIPTION
Fixes hook after this commit to dehydrated: https://github.com/lukas2511/dehydrated/commit/9ebab3e026569e79971fd7be14c522b22025150d

Without this fix dehydrated will error out:
```
 + CloudFlare hook executing: h03v/NxKh5XWYVoZxDl7yg==
Traceback (most recent call last):
  File "/etc/dehydrated/hooks/cloudflare/hook.py", line 206, in <module>
    main(sys.argv[1:])
  File "/etc/dehydrated/hooks/cloudflare/hook.py", line 202, in main
    ops[argv[0]](argv[1:])
KeyError: 'h03v/NxKh5XWYVoZxDl7yg=='
```