### PR TITLE
fix ValueError in invalid_challenge

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -155,7 +155,7 @@ def unchanged_cert(args):
     
 
 def invalid_challenge(args):
-    domain, result = args
+    domain, result = args[0], " ".join(args[1:])
     logger.debug(' + invalid_challenge for {0}'.format(domain))
     logger.debug(' + Full error: {0}'.format(result))
     return


### PR DESCRIPTION
The error message may contain spaces and seems to be not quoted by dehydrated.

The error this fixes looks like this in the logs:

```
 + CloudFlare hook executing: invalid_challenge
Traceback (most recent call last):
  File "/opt/dehydrated-cloudflare-hook/hook.py", line 207, in <module>
    main(sys.argv[1:])
  File "/opt/dehydrated-cloudflare-hook/hook.py", line 204, in main
    ops[argv[0]](argv[1:])
  File "/opt/dehydrated-cloudflare-hook/hook.py", line 159, in invalid_challenge
    domain, result = args
ValueError: too many values to unpack (expected 2)
```

with the fix this turns into:

```
 + CloudFlare hook executing: invalid_challenge
 + invalid_challenge for *.[redacted]
 + Full error: { "type": "dns-01", "status": "invalid", "error": { "type": "urn:ietf:params:acme:error:unauthorized", "detail": "No TXT record found at _acme-challenge.[redacted]", "status": 403 }, "url": "https://acme-v02.api.letsencrypt.org/acme/challenge/[redacted]", "token": "[redacted]" }
ERROR: Challenge is invalid! (returned: invalid) (result: {
  "type": "dns-01",
  "status": "invalid",
  "error": {
    "type": "urn:ietf:params:acme:error:unauthorized",
    "detail": "No TXT record found at _acme-challenge.[redacted]",
    "status": 403
  },
  "url": "https://acme-v02.api.letsencrypt.org/acme/challenge/[redacted]",
  "token": "[redacted]"
})
```
