### PR TITLE
Make the time spend waiting for things to settle down configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Optionally, you can specify the DNS servers to be used for propagation checking 
 $ export CF_DNS_SERVERS='8.8.8.8 8.8.4.4'
 ```
 
+If you experience problems with DNS propagation, increasing the time (in seconds) this hooks waits for things to settle down after setting the DNS records, may help. The default is 10.
+
+```
+$ export CF_SETTLE_TIME='30'
+```
+
 If you want more information about what is going on while the hook is running:
 
 ```

--- a/hook.py
+++ b/hook.py
@@ -162,12 +162,13 @@ def invalid_challenge(args):
 
 
 def create_all_txt_records(args):
+    settle_time = int(os.environ.get('CF_SETTLE_TIME', '10'))
     X = 3
     for i in range(0, len(args), X):
         create_txt_record(args[i:i+X])
-    # give it 10 seconds to settle down and avoid nxdomain caching
-    logger.info(" + Settling down for 10s...")
-    time.sleep(10)
+    # give it some time (default: 10 seconds) to settle down and avoid nxdomain caching
+    logger.info(" + Settling down for {}s...".format(settle_time))
+    time.sleep(settle_time)
     for i in range(0, len(args), X):
         domain, token = args[i], args[i+2]
         name = "{0}.{1}".format('_acme-challenge', domain)


### PR DESCRIPTION
I had some trouble while requesting my first wildcard certificate, because Let's Encrypt checked the challenge to quickly. I thought making it the time spend waiting for things to settle down configurable was the most sensible option to avoid these problems in the future. I currently use 30s.