### PR TITLE
Support newer tld module versions

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import division
@@ -18,7 +18,7 @@ import requests
 import sys
 import time
 
-from tld import get_tld
+import tld
 
 # Enable verified HTTPS requests on older Pythons
 # http://urllib3.readthedocs.org/en/latest/security.html
@@ -76,8 +76,13 @@ def _has_dns_propagated(name, token):
 
 # https://api.cloudflare.com/#zone-list-zones
 def _get_zone_id(domain):
-    tld = get_tld('http://' + domain)
-    url = "https://api.cloudflare.com/client/v4/zones?name={0}".format(tld)
+    if hasattr(tld, 'fld'):
+        # for newer versions of tld, use get_fld
+        root_domain = tld.get_fld('http://' + domain)
+    else:
+        # for older versions of tld, use get_tld
+        root_domain = tld.get_tld('http://' + domain)
+    url = "https://api.cloudflare.com/client/v4/zones?name={0}".format(root_domain)
     r = requests.get(url, headers=CF_HEADERS)
     r.raise_for_status()
     return r.json()['result'][0]['id']

--- a/hook.py
+++ b/hook.py
@@ -63,14 +63,14 @@ def _has_dns_propagated(name, token):
             dns_response = custom_resolver.query(name, 'TXT')
         else:
             dns_response = dns.resolver.query(name, 'TXT')
-            
+
         for rdata in dns_response:
             if token in [b.decode('utf-8') for b in rdata.strings]:
                 return True
-                
+
     except dns.exception.DNSException as e:
         logger.debug(" + {0}. Retrying query...".format(e))
-        
+
     return False
 
 
@@ -109,12 +109,12 @@ def create_txt_record(args):
     logger.debug(' + Challenge: {0}'.format(challenge))
     zone_id = _get_zone_id(domain)
     name = "{0}.{1}".format('_acme-challenge', domain)
-    
+
     record_id = _get_txt_record_id(zone_id, name, token)
     if record_id:
         logger.debug(" + TXT record exists, skipping creation.")
         return
-    
+
     url = "https://api.cloudflare.com/client/v4/zones/{0}/dns_records".format(zone_id)
     payload = {
         'type': 'TXT',
@@ -157,7 +157,7 @@ def deploy_cert(args):
 
 def unchanged_cert(args):
     return
-    
+
 
 def invalid_challenge(args):
     domain, result = args


### PR DESCRIPTION
I noticed a problem when using apt to install python3-tld package, by default I got a newer version which has an incompatible version of get_tld. The new tld module has a get_fld which is what the hook.py needs so I updated the code to do the right thing regardless of tld module version. Note: on the raspberry pi OS, pip is not installed by default so using apt to install the tld module/package is a better fit.